### PR TITLE
Be consistent about overrides from info

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install alchemista
 
 Simply call the `sqlalchemy_to_pydantic` function with a SQLAlchemy model.
 Each `Column` in its definition will result in an attribute of the generated model via the Pydantic `Field` function.
-The supported attributes are listed in `alchemista.field.FieldKwargs`.
+The supported attributes are listed in `alchemista.field.Info`.
 Some of them can be extracted from `Column` attributes directly, like the default value and the description.
 
 For example, a SQLAlchemy model like the following

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ There is also an `exclude` keyword argument that accepts a set of field names to
 
 ### The `info` dictionary
 
-All attributes, except for a default scalar value, can be specified via the `info` dictionary of `Column`.
+All attributes can be specified via the `info` dictionary of `Column`.
 This includes what is inferred from column attributes directly, like the description shown previously.
-Everything specified in `info` is preferred from what is inferred.
+**Everything specified in `info` is preferred from what is inferred**.
 
 For example, in the case above,
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 
-class Person(Base):
+class PersonDB(Base):
     __tablename__ = "people"
 
     id = Column(Integer, primary_key=True)
@@ -46,7 +46,7 @@ could have a generated Pydantic model via
 ```python
 from alchemista import sqlalchemy_to_pydantic
 
-PersonPydantic = sqlalchemy_to_pydantic(Person)
+Person = sqlalchemy_to_pydantic(PersonDB)
 ```
 
 and would result in a Pydantic model equivalent to
@@ -68,6 +68,8 @@ Note that the string length from the column definition was sufficient to add a `
 Additionally, by default, the generated model will have `orm_mode=True`.
 That can be customized via the `config` keyword argument.
 There is also an `exclude` keyword argument that accepts a set of field names to _not_ include in the generated model.
+
+This example is available in a short executable form in the [`examples/`](examples/) directory.
 
 ### The `info` dictionary
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ pip install alchemista
 
 Simply call the `sqlalchemy_to_pydantic` function with a SQLAlchemy model.
 Each `Column` in its definition will result in an attribute of the generated model via the Pydantic `Field` function.
-The supported attributes are listed in `alchemista.field.Info`.
-Some of them can be extracted from `Column` attributes directly, like the default value and the description.
 
 For example, a SQLAlchemy model like the following
 
@@ -71,11 +69,19 @@ There is also an `exclude` keyword argument that accepts a set of field names to
 
 This example is available in a short executable form in the [`examples/`](examples/) directory.
 
-### The `info` dictionary
+## `Field` arguments and `info`
 
-All attributes can be specified via the `info` dictionary of `Column`.
-This includes what is inferred from column attributes directly, like the description shown previously.
-**Everything specified in `info` is preferred from what is inferred**.
+Currently, the type, default value (either scalar or callable), and the description (from the `doc` attribute) are
+extracted directly from the `Column` definition.
+However, except for the type, all of them can be overridden via the `info` dictionary attribute.
+All other custom arguments to the `Field` function are specified there too.
+The supported keys are listed in `alchemista.field.Info`.
+
+**Everything specified in `info` is preferred from what has been extracted from `Column`**.
+This means that the default value and the description can be **overridden** if so desired.
+Also, similarly to using Pydantic directly, `default` and `default_factory` are mutually-exclusive,
+so they cannot be used together.
+Use `default_factory` if the default value comes from calling a function (without any arguments).
 
 For example, in the case above,
 

--- a/alchemista/field.py
+++ b/alchemista/field.py
@@ -101,11 +101,13 @@ def make_field(column: Column) -> FieldInfo:  # type: ignore[type-arg]
         and column.default
         and column.default.is_callable
     ):
-        return cast(FieldInfo, Field(**field_kwargs, default_factory=column.default.arg.__wrapped__))
+        return cast(
+            FieldInfo, Field(**field_kwargs, default_factory=column.default.arg.__wrapped__)  # type: ignore[misc]
+        )
 
     if "default_factory" in field_kwargs:
         return cast(FieldInfo, Field(**field_kwargs))
 
     # pop `default` because it is not a keyword argument of `Field`
     default = field_kwargs.pop("default") if "default" in field_kwargs else _get_default_scalar(column)
-    return cast(FieldInfo, Field(default, **field_kwargs))
+    return cast(FieldInfo, Field(default, **field_kwargs))  # type: ignore[misc]

--- a/alchemista/field.py
+++ b/alchemista/field.py
@@ -7,7 +7,7 @@ from sqlalchemy.types import TypeEngine
 from typing_extensions import TypedDict
 
 
-class FieldKwargs(TypedDict, total=False):
+class Info(TypedDict, total=False):
     alias: str
     allow_mutation: bool
     const: Any
@@ -61,7 +61,7 @@ def _get_default_scalar(column: Column) -> Any:  # type: ignore[type-arg]
     return None
 
 
-def _set_max_length_from_column_if_present(field_kwargs: FieldKwargs, column: Column) -> None:  # type: ignore[type-arg]
+def _set_max_length_from_column_if_present(field_kwargs: Info, column: Column) -> None:  # type: ignore[type-arg]
     # some types have a length in the backend, but setting that interferes with the model generation
     # maybe we should list the types that we *should set* the length, instead of *not set* the length?
     if not isinstance(column.type, Enum):
@@ -78,9 +78,9 @@ def _set_max_length_from_column_if_present(field_kwargs: FieldKwargs, column: Co
 
 
 def make_field(column: Column) -> FieldInfo:  # type: ignore[type-arg]
-    field_kwargs = FieldKwargs()
+    field_kwargs = Info()
     if column.info:
-        for key in FieldKwargs.__annotations__.keys():
+        for key in Info.__annotations__.keys():
             if key in column.info:
                 field_kwargs[key] = column.info[key]  # type: ignore[misc]
 

--- a/examples/simple_person.py
+++ b/examples/simple_person.py
@@ -1,0 +1,35 @@
+import json
+
+from alchemista import sqlalchemy_to_pydantic
+from sqlalchemy import Column, Integer, String, create_engine, select
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+
+Base = declarative_base()
+engine = create_engine("sqlite://")
+
+
+class PersonDB(Base):
+    __tablename__ = "people"
+
+    id = Column(Integer, primary_key=True)
+    age = Column(Integer, default=0, nullable=False, doc="Age in years")
+    name = Column(String(128), nullable=False, doc="Full name")
+
+
+Person = sqlalchemy_to_pydantic(PersonDB)
+print("Schema of generated model:")
+print(json.dumps(Person.schema(), indent=4))
+
+
+Base.metadata.create_all(engine)
+SessionMaker = sessionmaker(bind=engine)
+
+person = Person.construct(name="Someone", age=25)
+with SessionMaker.begin() as session:
+    session.add(PersonDB(**person.dict()))
+
+with SessionMaker.begin() as session:
+    person_db = session.execute(select(PersonDB)).scalar_one()
+    person = Person.from_orm(person_db)
+    print("Instance of model loaded from database:", person)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "alchemista"
-version = "0.1.0.post2"
+version = "0.1.1"
 description = "Tools to convert SQLAlchemy models to Pydantic models"
 license = "MIT"
 authors = ["Gabriel Galli <ggabriel96@hotmail.com>"]

--- a/tests/field/test_make_field.py
+++ b/tests/field/test_make_field.py
@@ -118,18 +118,35 @@ def test_length_comes_from_column_definition() -> None:
     assert field.title is None
 
 
-def test_length_from_info_must_match_column_definition() -> None:
+def test_length_from_info_overrides_that_of_column() -> None:
     # Arrange
     max_length = 64
-    column = Column("column", String(max_length), info=dict(max_length=max_length + 1))
+    expected_max_length = 32
+    column = Column("column", String(max_length), info=dict(max_length=expected_max_length))
 
-    # Act / Assert
-    with pytest.raises(ValueError) as ex:
-        make_field(column)
-    assert str(ex.value) == (
-        f"max_length ({max_length + 1}) of `info` differs from length set in column type ({max_length}) on column"
-        f" `{column.name}`. Either remove max_length from `info` (preferred) or set them to equal values"
-    )
+    # Act
+    field = make_field(column)
+
+    # Assert
+    assert field.max_length == expected_max_length
+
+    assert field.alias is None
+    assert field.alias_priority is None
+    assert field.const is None
+    assert field.default is None
+    assert field.default_factory is None
+    assert field.description is None
+    assert field.extra == {}
+    assert field.ge is None
+    assert field.gt is None
+    assert field.le is None
+    assert field.lt is None
+    assert field.max_items is None
+    assert field.min_items is None
+    assert field.min_length is None
+    assert field.multiple_of is None
+    assert field.regex is None
+    assert field.title is None
 
 
 def test_default_comes_from_column_definition() -> None:

--- a/tests/field/test_make_field.py
+++ b/tests/field/test_make_field.py
@@ -6,14 +6,14 @@ import pytest
 from pydantic.fields import Undefined
 from sqlalchemy import Column, Integer, String, Text
 
-from alchemista.field import FieldKwargs, make_field
+from alchemista.field import Info, make_field
 
 
 def test_field_kwargs_used_as_info() -> None:
     # Arrange
     column = Column(
         Integer,
-        info=FieldKwargs(
+        info=Info(
             alias="n",
             const=0,
             description="Some multiple of 2",

--- a/tests/field/test_make_field.py
+++ b/tests/field/test_make_field.py
@@ -9,7 +9,7 @@ from sqlalchemy import Column, Integer, String, Text
 from alchemista.field import Info, make_field
 
 
-def test_field_kwargs_used_as_info() -> None:
+def test_info_type_used_as_info() -> None:
     # Arrange
     column = Column(
         Integer,

--- a/tests/field/test_make_field.py
+++ b/tests/field/test_make_field.py
@@ -48,35 +48,6 @@ def test_field_kwargs_used_as_info() -> None:
     assert field.title == "Multiple of Two"
 
 
-def test_default_comes_from_column_definition() -> None:
-    # Arrange
-    column = Column(Integer, default=2)
-
-    # Act
-    field = make_field(column)
-
-    # Assert
-    assert field.default == 2
-
-    assert field.alias is None
-    assert field.alias_priority is None
-    assert field.const is None
-    assert field.default_factory is None
-    assert field.description is None
-    assert field.extra == {}
-    assert field.ge is None
-    assert field.gt is None
-    assert field.le is None
-    assert field.lt is None
-    assert field.max_items is None
-    assert field.max_length is None
-    assert field.min_items is None
-    assert field.min_length is None
-    assert field.multiple_of is None
-    assert field.regex is None
-    assert field.title is None
-
-
 @pytest.mark.parametrize(
     "doc,info,expected",
     [
@@ -161,6 +132,93 @@ def test_length_from_info_must_match_column_definition() -> None:
     )
 
 
+def test_default_comes_from_column_definition() -> None:
+    # Arrange
+    column = Column(Integer, default=2)
+
+    # Act
+    field = make_field(column)
+
+    # Assert
+    assert field.default == 2
+
+    assert field.alias is None
+    assert field.alias_priority is None
+    assert field.const is None
+    assert field.default_factory is None
+    assert field.description is None
+    assert field.extra == {}
+    assert field.ge is None
+    assert field.gt is None
+    assert field.le is None
+    assert field.lt is None
+    assert field.max_items is None
+    assert field.max_length is None
+    assert field.min_items is None
+    assert field.min_length is None
+    assert field.multiple_of is None
+    assert field.regex is None
+    assert field.title is None
+
+
+def test_default_from_info_overrides_that_of_column() -> None:
+    # Arrange
+    column = Column("column", Integer, default=0, info=dict(default=1))
+
+    # Act
+    field = make_field(column)
+
+    # Assert
+    assert field.default == 1
+
+    assert field.alias is None
+    assert field.alias_priority is None
+    assert field.const is None
+    assert field.default_factory is None
+    assert field.description is None
+    assert field.extra == {}
+    assert field.ge is None
+    assert field.gt is None
+    assert field.le is None
+    assert field.lt is None
+    assert field.max_items is None
+    assert field.max_length is None
+    assert field.min_items is None
+    assert field.min_length is None
+    assert field.multiple_of is None
+    assert field.regex is None
+    assert field.title is None
+
+
+def test_default_from_info_overrides_that_of_column_when_none_too() -> None:
+    # Arrange
+    column = Column("column", Integer, default=None, info=dict(default=1))
+
+    # Act
+    field = make_field(column)
+
+    # Assert
+    assert field.default == 1
+
+    assert field.alias is None
+    assert field.alias_priority is None
+    assert field.const is None
+    assert field.default_factory is None
+    assert field.description is None
+    assert field.extra == {}
+    assert field.ge is None
+    assert field.gt is None
+    assert field.le is None
+    assert field.lt is None
+    assert field.max_items is None
+    assert field.max_length is None
+    assert field.min_items is None
+    assert field.min_length is None
+    assert field.multiple_of is None
+    assert field.regex is None
+    assert field.title is None
+
+
 def test_lambda_as_default_factory() -> None:
     # Arrange
     default_factory = lambda: "dynamic default"
@@ -227,3 +285,52 @@ def test_datetime_now_as_default_factory() -> None:
     assert field.multiple_of is None
     assert field.regex is None
     assert field.title is None
+
+
+def test_default_factory_from_info_overrides_default_of_column() -> None:
+    # Arrange
+    expected_factory = lambda: "info default factory"
+    column = Column(
+        "column",
+        Text,
+        default=lambda: "column dynamic default",
+        info=dict(default_factory=expected_factory),
+    )
+
+    # Act
+    field = make_field(column)
+
+    # Assert
+    assert field.default is Undefined
+    assert field.default_factory is expected_factory
+    assert field.default_factory() == "info default factory"
+
+    assert field.alias is None
+    assert field.alias_priority is None
+    assert field.const is None
+    assert field.description is None
+    assert field.extra == {}
+    assert field.ge is None
+    assert field.gt is None
+    assert field.le is None
+    assert field.lt is None
+    assert field.max_items is None
+    assert field.max_length is None
+    assert field.min_items is None
+    assert field.min_length is None
+    assert field.multiple_of is None
+    assert field.regex is None
+    assert field.title is None
+
+
+def test_default_conflicts_with_default_factory() -> None:
+    # Arrange
+    column = Column("column", Integer, info=dict(default=0, default_factory=lambda: 1))
+
+    # Act / Assert
+    with pytest.raises(ValueError) as ex:
+        make_field(column)
+    assert str(ex.value) == (
+        f"Both `default` and `default_factory` were specified in info of column `{column.name}`."
+        " These two attributes are mutually-exclusive"
+    )


### PR DESCRIPTION
- from now on, everything in `info` overrides what has been extracted from `Column`
    - added `default` as possible `info` argument so that it can be overriden
    - removed restriction about `max_length`
    - using `default` and `default_factory` simultaneously now raises a an error before calling into Pydantic
- renamed `FieldKwargs` to `Info` since it contains more stuff than keyword arguments for the `Field` function (the `default`)
- updated README
- added an example that was previously in the README as an executable example in `examples/`