### PR TITLE
Fix Python usage in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Load dependency cache
         id: dependency-cache
         uses: actions/cache@v2
-        with: &cache-args
+        with:
           path: .venv/
           key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
@@ -57,7 +57,8 @@ jobs:
         id: dependency-cache
         uses: actions/cache@v2
         with:
-          <<: *cache-args
+          path: .venv/
+          key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-in-project: true
+          virtualenvs-create: false
 
       - name: Load dependency cache
         id: dependency-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-create: false
+          virtualenvs-create: true
           virtualenvs-in-project: true
 
       - name: Load dependency cache
@@ -52,7 +52,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-create: false
+          virtualenvs-create: true
           virtualenvs-in-project: true
 
       - name: Load dependency cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run tests
-        run: pytest --cov=alchemista/ --cov-report=xml --verbose tests/
+        run: poetry run pytest --cov=alchemista/ --cov-report=xml --verbose tests/
 
       - uses: codecov/codecov-action@v1
         if: matrix.python-version == '3.6'
@@ -67,12 +67,12 @@ jobs:
 
       - name: Black
         if: always()
-        run: black --check --verbose alchemista/ tests/
+        run: poetry run black --check --verbose alchemista/ tests/
 
       - name: Mypy
         if: always()
-        run: mypy --verbose alchemista/ tests/
+        run: poetry run mypy --verbose alchemista/ tests/
 
       - name: Pylint
         if: always()
-        run: pylint --verbose alchemista/ tests/
+        run: poetry run pylint --verbose alchemista/ tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,7 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run tests
-        run: |
-          source .venv/bin/activate
-          pytest --cov=alchemista/ --cov-report=xml tests/
+        run: pytest --cov=alchemista/ --cov-report=xml tests/
 
       - uses: codecov/codecov-action@v1
         if: matrix.python-version == '3.6'
@@ -67,18 +65,12 @@ jobs:
 
       - name: Black
         if: always()
-        run: |
-          source .venv/bin/activate
-          black --check alchemista/ tests/
+        run: black --check alchemista/ tests/
 
       - name: Mypy
         if: always()
-        run: |
-          source .venv/bin/activate
-          mypy alchemista/ tests/
+        run: mypy alchemista/ tests/
 
       - name: Pylint
         if: always()
-        run: |
-          source .venv/bin/activate
-          pylint alchemista/ tests/
+        run: pylint alchemista/ tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Load dependency cache
         id: dependency-cache
         uses: actions/cache@v2
-        with:
+        with: &cache-args
           path: .venv/
           key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
@@ -57,8 +57,7 @@ jobs:
         id: dependency-cache
         uses: actions/cache@v2
         with:
-          path: .venv/
-          key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          <<: *cache-args
 
       - name: Install dependencies
         run: poetry install --no-interaction

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv/
-          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+          key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         if: steps.dependency-cache.outputs.cache-hit != 'true'
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv/
-          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+          key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         if: steps.dependency-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv/
-          key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: venv-v0-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv/
-          key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: venv-v0-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
           key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.dependency-cache.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
 
       - name: Run tests
@@ -64,7 +63,6 @@ jobs:
           key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.dependency-cache.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
 
       - name: Black

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
         uses: snok/install-poetry@v1.1.4
         with:
           virtualenvs-create: false
+          virtualenvs-in-project: true
 
       - name: Load dependency cache
         id: dependency-cache
@@ -52,6 +53,7 @@ jobs:
         uses: snok/install-poetry@v1.1.4
         with:
           virtualenvs-create: false
+          virtualenvs-in-project: true
 
       - name: Load dependency cache
         id: dependency-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-in-project: true
+          virtualenvs-create: false
 
       - name: Load dependency cache
         id: dependency-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run tests
-        run: pytest --cov=alchemista/ --cov-report=xml tests/
+        run: pytest --cov=alchemista/ --cov-report=xml --verbose tests/
 
       - uses: codecov/codecov-action@v1
         if: matrix.python-version == '3.6'
@@ -65,12 +65,12 @@ jobs:
 
       - name: Black
         if: always()
-        run: black --check alchemista/ tests/
+        run: black --check --verbose alchemista/ tests/
 
       - name: Mypy
         if: always()
-        run: mypy alchemista/ tests/
+        run: mypy --verbose alchemista/ tests/
 
       - name: Pylint
         if: always()
-        run: pylint alchemista/ tests/
+        run: pylint --verbose alchemista/ tests/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-in-project: true
+          virtualenvs-create: false
 
       - name: Load dependency cache
         id: dependency-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv/
-          key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+          key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         if: steps.dependency-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,6 @@ jobs:
           key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.dependency-cache.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
 
       - name: Publish to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1.1.4
         with:
-          virtualenvs-create: false
+          virtualenvs-create: true
           virtualenvs-in-project: true
 
       - name: Load dependency cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv/
-          key: venv-v1-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: venv-v0-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install dependencies
         run: poetry install --no-interaction

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
         uses: snok/install-poetry@v1.1.4
         with:
           virtualenvs-create: false
+          virtualenvs-in-project: true
 
       - name: Load dependency cache
         id: dependency-cache


### PR DESCRIPTION
Different Python versions were not configured correctly, leading to not being actually used to test in these different versions.
Now Poetry is set to create virtual environments and everything is run via `poetry run`.

Additionally, there was only one cache for all versions. Now there is one cache for each version. Also versioned the name so we can easily invalidate them when needed.